### PR TITLE
hash the hash results

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -16,9 +16,9 @@ def calculate_probability_of_false_positive():
 
 
 if __name__ == '__main__':
-    print "num hash functions: ".ljust(20) + "{depth}".format(depth=DEPTH)
+    print "\nnum hash functions: ".ljust(20) + "{depth}".format(depth=DEPTH)
     print "num inserted: ".ljust(20) + "{inserted}".format(inserted=NUM_INSERT)
-    print "num 'bits': ".ljust(20) + "{size}".format(size=SIZE)
-    print "{p} probability of false positive".format(
+    print "num 'bits': ".ljust(20) + "{size}\n".format(size=SIZE)
+    print "{p} probability of false positive\n".format(
         p=calculate_probability_of_false_positive()
     )

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,24 @@
+import math
+
+DEPTH = 20
+NUM_INSERT = 10 ** 3
+SIZE = 10 ** 7
+
+
+def calculate_probability_of_false_positive():
+    prob = (
+        1 - math.e ** (
+            -1 * DEPTH * NUM_INSERT / SIZE
+        )
+    ) ** DEPTH
+
+    return prob
+
+
+if __name__ == '__main__':
+    print "num hash functions: ".ljust(20) + "{depth}".format(depth=DEPTH)
+    print "num inserted: ".ljust(20) + "{inserted}".format(inserted=NUM_INSERT)
+    print "num 'bits': ".ljust(20) + "{size}".format(size=SIZE)
+    print "{p} probability of false positive".format(
+        p=calculate_probability_of_false_positive()
+    )

--- a/bloom_filter.py
+++ b/bloom_filter.py
@@ -1,26 +1,29 @@
 class BloomFilter(object):
-    def __init__(self):
-        self.space = [None] * 10 ** 7
+    def __init__(self, depth=3, size=10 ** 7):
+        self.depth  = depth
+        self.size   = size
+        self.space  = [None] * self.size
+
+    def _hash(self, element):
+        index = hash(element) % self.size
+
+        return index
+
 
     def add(self, element):
-        self.space[hash1(element)] = True
-        self.space[hash2(element)] = True
-        self.space[hash3(element)] = True
+        for _ in xrange(self.depth):
+            index = self._hash(element)
+            self.space[index] = True
+            element = index
 
         return True
 
     def has(self, element):
-        return (
-            self.space[hash1(element)]
-            or self.space[hash2(element)]
-            or self.space[hash3(element)]
-        )
+        for _ in xrange(self.depth):
+            index = self._hash(element)
+            if self.space[index]:
+                return True
 
-def hash1(element):
-    return hash(element) % 10 ** 7
+            element = index
 
-def hash2(element):
-    return hash(element) % 10 ** 7 + 10
-
-def hash3(element):
-    return hash(element) % 10 ** 7 + 1000
+        return False

--- a/bloom_filter_test.py
+++ b/bloom_filter_test.py
@@ -2,17 +2,21 @@ import unittest
 import string
 import random
 
+from . import DEPTH, SIZE, NUM_INSERT
 from .bloom_filter import BloomFilter
+
 
 class TestBloomFilter(unittest.TestCase):
     def setUp(self):
-        self.bf = BloomFilter()
-        self.test_length = 1000
+        self.bf = BloomFilter(
+            depth=DEPTH,
+            size=SIZE,
+        )
+        self.test_length = NUM_INSERT # KW: numer if inserted elements
         self.element_length = 10
 
     def test_add(self):
         assert self.bf.add(create_random_string(self.element_length))
-
 
     def test_basic_add_check(self):
         positives = []
@@ -33,6 +37,8 @@ class TestBloomFilter(unittest.TestCase):
             assert not self.bf.has(e)
 
         print "{count} negatives assertions true".format(count=len(negatives))
+
+
 
 def create_random_string(length):
     s = ''.join(


### PR DESCRIPTION
doubling num hash functions decreases probability of false positive by 10x and has little effect on speed

```
[kevin@Kevins-MacBook-Pro bloom]$ python __init__.py

num hash functions: 5
num inserted:       1000
num 'bits':         10000000

0.100925190275 probability of false positive

[kevin@Kevins-MacBook-Pro bloom]$ python __init__.py

num hash functions: 10
num inserted:       1000
num 'bits':         10000000

0.010185894032 probability of false positive

[kevin@Kevins-MacBook-Pro bloom]$ python __init__.py

num hash functions: 20
num inserted:       1000
num 'bits':         10000000

0.000103752437231 probability of false positive

[kevin@Kevins-MacBook-Pro bloom]$ py.test
=================== test session starts ===================
platform darwin -- Python 2.7.10, pytest-3.0.5, py-1.4.32, pluggy-0.4.0
rootdir: /Users/kevin/Desktop/bloom, inifile: 
collected 2 items 

bloom_filter_test.py ..

====================== 2 passed in 0.23 seconds ======================
[kevin@Kevins-MacBook-Pro bloom]$ 
```